### PR TITLE
Fix version number in man page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: man
 man: tpfancod.8
 
 tpfancod.8: man/tpfancod.pod
-	pod2man --utf8 --section=8 --release=Version\ `cat src/tpfancod.py | grep "version = " | sed  -e "s/version = \"\(.*\)\"/\1/"` --center "" man/tpfancod.pod > tpfancod.8
+	pod2man --utf8 --section=8 --release="Version `cat src/tpfancod.py | grep \"version = \" | grep -o '[0-9]*\.[0-9]*\.[0-9]*'`" --center "" man/tpfancod.pod > tpfancod.8
 
 clean:
 	rm -f tpfancod.8


### PR DESCRIPTION
Using last git, I get an error when running `make`:

$ make
pod2man --utf8 --section=8 --release=Version\ `cat src/tpfancod.py | grep "version = " | sed  -e "s/version = \"\(.*\)\"/\1/"` --center "" man/tpfancod.pod > tpfancod.8
Can't open version: No such file or directory at /usr/bin/core_perl/pod2man line 68.
Makefile:8: recipe for target 'tpfancod.8' failed
make: **\* [tpfancod.8] Error 2

This commit address this issue by extracting the correct version from tpfancod.py.
