### PR TITLE
import after fixing path

### DIFF
--- a/src/tpfancod.py
+++ b/src/tpfancod.py
@@ -27,10 +27,10 @@ import sys
 
 import dbus.mainloop.glib
 import gobject
-from tpfancod import settings, control
 
 if not ('/usr/lib/python2.7/site-packages' in sys.path):
     sys.path.append('/usr/lib/python2.7/site-packages')
+from tpfancod import settings, control
 
 
 class Tpfancod(object):


### PR DESCRIPTION
Fix tpfancod ImportError (at least on Debian Jessie):

``` pytb
Traceback (most recent call last):
  File "/usr/sbin/tpfancod", line 30, in <module>
    from tpfancod import settings, control
ImportError: No module named tpfancod
```
